### PR TITLE
Add stripe customer id to user model

### DIFF
--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -77,6 +77,27 @@ class RequestsController < ApplicationController
     end
   end
 
+  def print_all
+    setup_date_range_picker
+
+    requests = current_organization
+      .ordered_requests
+      .undiscarded
+      .during(helpers.selected_range)
+      .class_filter(filter_params)
+      .includes(:item_requests, partner: [:profile])
+
+    respond_to do |format|
+      format.any do
+        pdf = PicklistsPdf.new(current_organization, requests)
+        send_data pdf.compute_and_render,
+          filename: format("Picklists_Filtered_%s.pdf", Time.current.to_fs(:long)),
+          type: "application/pdf",
+          disposition: "inline"
+      end
+    end
+  end
+
   private
 
   def load_items

--- a/app/views/requests/index.html.erb
+++ b/app/views/requests/index.html.erb
@@ -73,6 +73,12 @@
                         text: "Print Unfulfilled Picklists (#{@unfulfilled_requests_count})",
                         size: "md") %>
                     <% end %>
+                    <% if @requests.any? %>
+                      <%= print_button_to(
+                        print_all_requests_path(format: :pdf, filters: filter_params.merge(date_range: date_range_params)),
+                        text: "Print All (#{@requests.count})",
+                        size: "md") %>
+                    <% end %>
                     <%= download_button_to(requests_path(format: :csv, filters: filter_params.merge(date_range: date_range_params)), {text: "Export Requests", size: "md"}) if @requests.any? %>
                     <%= modal_button_to("#newRequest", text: "New Quantity Request", icon: "plus", type: "success") if current_user.has_role?(Role::ORG_ADMIN, current_organization) %>
                   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -244,6 +244,7 @@ Rails.application.routes.draw do
       post :start
     end
     get :print_unfulfilled, on: :collection
+    get :print_all, on: :collection
     get :print_picklist, on: :member
   end
   resources :requests, except: %i(destroy) do


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.
- I acknowledge that I will *not* force push my branch once reviews have started.

-->

Resolves #5329

### Description
This PR implements the "Print All" functionality for the requests index page. It allows users to generate a PDF picklist of all requests currently displayed and filtered on the page.

The changes include:
-   Adding a `print_all` route to `config/routes.rb`.
-   Creating a `print_all` action in `RequestsController` that applies existing filters (date range, partner, status, request type, item) to retrieve all matching requests and generates a PDF using `PicklistsPdf`.
-   Adding a "Print All" button to `app/views/requests/index.html.erb` which dynamically shows the count of filtered requests and passes current filter parameters to the new action.

This feature provides a comprehensive picklist for warehouse operations based on the user's current view.

### Type of change

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

Due to environment setup limitations, the application could not be run. The implementation was verified through:
-   Static code analysis for syntax correctness.
-   Manual review of the controller action, route, and view changes against existing patterns to ensure consistency and adherence to requirements.
-   A simple script was used to validate the syntax of modified files.

To fully verify, please:
1.  Run `bundle exec rake` to ensure all tests pass.
2.  Start the Rails application locally.
3.  Navigate to the requests index page.
4.  Apply various filters (e.g., date range, partner, status).
5.  Verify that the "Print All" button appears with the correct count.
6.  Click the "Print All" button and confirm that a PDF is generated containing only the filtered requests.

---
<a href="https://cursor.com/background-agent?bcId=bc-df086514-a2c1-492d-8929-ae10e8bcabcc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-df086514-a2c1-492d-8929-ae10e8bcabcc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

